### PR TITLE
Hiera setable env

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -39,6 +39,7 @@ class puppet::agent (
   $waitforcert            = '120',
   $logdest                = 'console',
   $clientbucket_dir       = '/opt/puppetlabs/puppet/cache/clientbucket',
+  $environment            = 'production',
 ) {
 
   include cron

--- a/templates/puppet.conf.epp
+++ b/templates/puppet.conf.epp
@@ -14,6 +14,7 @@ graph = <%= $::puppet::agent::graph %>
 pluginsync = <%= $::puppet::agent::pluginsync %>
 waitforcert = <%= $::puppet::agent::waitforcert %>
 clientbucketdir = <%= $::puppet::agent::clientbucketdir %>
+environment = <%= $::puppet::agent::environment %>
 
 <% if $::puppet::serverrole == 'true' { -%>
 [master]


### PR DESCRIPTION
added ability to set the puppet environment via hiera. 
by default 'production is set'
