### PR TITLE
prefer custom env fact for environment

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -68,6 +68,14 @@ class puppet::agent (
     $cron_real_min = $cron_minute
   }
 
+  #prefer custom env fact
+  if $::env {
+    $myenvironment = $::env
+  }
+  else {
+    $myenvironment = $environment
+  }
+
   package { $package_name:
     ensure => $package_ensure,
   }

--- a/templates/puppet.conf.epp
+++ b/templates/puppet.conf.epp
@@ -16,7 +16,7 @@ graph = <%= $::puppet::agent::graph %>
 pluginsync = <%= $::puppet::agent::pluginsync %>
 waitforcert = <%= $::puppet::agent::waitforcert %>
 clientbucketdir = <%= $::puppet::agent::clientbucketdir %>
-environment = <%= $::puppet::agent::environment %>
+environment = <%= $::puppet::agent::myenvironment %>
 
 <% if $::puppet::serverrole == 'true' { -%>
 [master]


### PR DESCRIPTION
this is needed to have the functionality either to set the puppet::envrionment in hiera or use the custom env fact which is deployed in our infrastructure with razor installations
